### PR TITLE
docs: add comprehensive README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # claude-github-playground
+
+A playground repository for learning and testing Claude Code GitHub integration.
+
+## About
+
+This repository is designed to experiment with Claude Code's GitHub capabilities, including:
+
+- Creating branches and commits
+- Opening pull requests
+- Following repository-specific rules defined in CLAUDE.md
+- Testing automated workflows
+
+## How It Works
+
+Claude Code follows the rules defined in [CLAUDE.md](./CLAUDE.md), which specify:
+
+- Branch management practices
+- Commit message standards
+- Pull request workflows
+- Safety guidelines
+
+## Getting Started
+
+1. Create an issue with a task description
+2. Mention `@claude` in the issue
+3. Claude Code will create a branch, make changes, and open a PR
+
+## Learn More
+
+- [Claude Code Documentation](https://claude.ai/code)
+- [GitHub Actions](https://github.com/features/actions)


### PR DESCRIPTION
Fixes #4

The README.md file was empty on the main branch. This PR adds:

- Description of repository purpose
- About section explaining Claude Code integration testing
- How It Works section referencing CLAUDE.md
- Getting Started guide
- Links to Claude Code and GitHub Actions documentation

Generated with [Claude Code](https://claude.ai/code)